### PR TITLE
test-step 0.1.1

### DIFF
--- a/steps/test-step/0.1.1/step.yml
+++ b/steps/test-step/0.1.1/step.yml
@@ -1,0 +1,52 @@
+title: test_step
+summary: |
+  a PoC custom step to test how the workflow GUI handles a custom steplib when run locally
+description: |
+  see summary
+website: https://github.com/JonOpacich/bitrise-steplib
+source_code_url: https://github.com/JonOpacich/bitrise-steplib
+support_url: https://github.com/JonOpacich/bitrise-steplib
+published_at: 2020-05-27T20:28:12.978735-05:00
+source:
+  git: https://github.com/JonOpacich/test_step.git
+  commit: 62b69c8dc83c0a63fd3c7fde6e2449d3529f3eea
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: wget
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- example_step_input: Default Value - you can leave this empty if you want to
+  opts:
+    description: |
+      Description of this input.
+
+      Can be Markdown formatted text.
+    is_expand: true
+    is_required: true
+    summary: Summary. No more than 2-3 sentences.
+    title: Example Step Input
+    value_options: []
+outputs:
+- EXAMPLE_STEP_OUTPUT: null
+  opts:
+    description: |
+      Description of this output.
+
+      Can be Markdown formatted text.
+    summary: Summary. No more than 2-3 sentences.
+    title: Example Step Output


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
